### PR TITLE
Add Stripe payment gateway integration for Evershop

### DIFF
--- a/src/lib/evershop/stripe/client.ts
+++ b/src/lib/evershop/stripe/client.ts
@@ -1,0 +1,77 @@
+import { StripeGatewayConfig } from './types';
+import { StripeRequestError } from './errors';
+
+const STRIPE_API_BASE_URL = 'https://api.stripe.com/v1';
+
+export interface StripeRequestOptions {
+  method?: 'GET' | 'POST';
+  body?: URLSearchParams | string;
+  idempotencyKey?: string;
+}
+
+export interface StripeClient {
+  request<T>(path: string, options?: StripeRequestOptions): Promise<T>;
+}
+
+function resolveBody(body?: URLSearchParams | string) {
+  if (!body) {
+    return undefined;
+  }
+
+  if (typeof body === 'string') {
+    return body;
+  }
+
+  return body.toString();
+}
+
+function resolveHeaders(config: StripeGatewayConfig, options?: StripeRequestOptions) {
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${config.secretKey}`,
+  };
+
+  if (options?.body instanceof URLSearchParams) {
+    headers['Content-Type'] = 'application/x-www-form-urlencoded';
+  }
+
+  if (options?.idempotencyKey) {
+    headers['Idempotency-Key'] = options.idempotencyKey;
+  }
+
+  return headers;
+}
+
+function extractStripeErrorDetails(body: Record<string, unknown>) {
+  const error = body?.error as Record<string, unknown> | undefined;
+  return {
+    type: (error?.type as string | undefined) ?? 'unknown_error',
+    message: (error?.message as string | undefined) ?? 'Unknown Stripe error',
+  };
+}
+
+export function createStripeClient(config: StripeGatewayConfig): StripeClient {
+  return {
+    async request<T>(path: string, options?: StripeRequestOptions): Promise<T> {
+      const url = `${STRIPE_API_BASE_URL}${path}`;
+      const response = await fetch(url, {
+        method: options?.method ?? 'POST',
+        headers: resolveHeaders(config, options),
+        body: resolveBody(options?.body),
+      });
+
+      const responseBody = (await response.json()) as Record<string, unknown>;
+
+      if (!response.ok) {
+        const { type, message } = extractStripeErrorDetails(responseBody);
+        throw new StripeRequestError(message, {
+          status: response.status,
+          type,
+          requestId: response.headers.get('request-id') ?? undefined,
+          rawBody: responseBody,
+        });
+      }
+
+      return responseBody as T;
+    },
+  };
+}

--- a/src/lib/evershop/stripe/config.ts
+++ b/src/lib/evershop/stripe/config.ts
@@ -1,0 +1,44 @@
+import { StripeConfigurationError } from './errors';
+import { StripeGatewayConfig } from './types';
+
+export interface StripeConfigEnvironment {
+  STRIPE_SECRET_KEY?: string;
+  STRIPE_PUBLISHABLE_KEY?: string;
+  STRIPE_WEBHOOK_SECRET?: string;
+  STRIPE_CURRENCY?: string;
+  STRIPE_CAPTURE_METHOD?: string;
+}
+
+function normaliseCaptureMethod(value?: string) {
+  if (!value) {
+    return undefined;
+  }
+
+  const captureMethod = value.toLowerCase();
+  if (captureMethod !== 'automatic' && captureMethod !== 'manual') {
+    throw new StripeConfigurationError(
+      `Unsupported Stripe capture method "${value}". Valid options are "automatic" or "manual".`,
+    );
+  }
+
+  return captureMethod;
+}
+
+export function buildStripeGatewayConfigFromEnv(
+  env: StripeConfigEnvironment,
+  overrides: Partial<StripeGatewayConfig> = {},
+): StripeGatewayConfig {
+  const config: StripeGatewayConfig = {
+    secretKey: env.STRIPE_SECRET_KEY ?? overrides.secretKey ?? '',
+    publishableKey: env.STRIPE_PUBLISHABLE_KEY ?? overrides.publishableKey ?? '',
+    webhookSecret: env.STRIPE_WEBHOOK_SECRET ?? overrides.webhookSecret ?? '',
+    currency: env.STRIPE_CURRENCY ?? overrides.currency ?? '',
+    captureMethod:
+      (overrides.captureMethod ?? normaliseCaptureMethod(env.STRIPE_CAPTURE_METHOD)) ?? undefined,
+    metadata: overrides.metadata,
+    automaticPaymentMethods: overrides.automaticPaymentMethods,
+    paymentMethodTypes: overrides.paymentMethodTypes,
+  };
+
+  return config;
+}

--- a/src/lib/evershop/stripe/errors.ts
+++ b/src/lib/evershop/stripe/errors.ts
@@ -1,0 +1,43 @@
+export class StripeGatewayError extends Error {
+  constructor(message: string, public readonly cause?: unknown) {
+    super(message);
+    this.name = 'StripeGatewayError';
+  }
+}
+
+export class StripeConfigurationError extends StripeGatewayError {
+  constructor(message: string) {
+    super(message);
+    this.name = 'StripeConfigurationError';
+  }
+}
+
+export interface StripeRequestErrorOptions {
+  status: number;
+  requestId?: string;
+  type?: string;
+  rawBody: unknown;
+}
+
+export class StripeRequestError extends StripeGatewayError {
+  public readonly status: number;
+  public readonly requestId?: string;
+  public readonly type?: string;
+  public readonly rawBody: unknown;
+
+  constructor(message: string, options: StripeRequestErrorOptions) {
+    super(message);
+    this.name = 'StripeRequestError';
+    this.status = options.status;
+    this.requestId = options.requestId;
+    this.type = options.type;
+    this.rawBody = options.rawBody;
+  }
+}
+
+export class StripeSignatureVerificationError extends StripeGatewayError {
+  constructor(message: string) {
+    super(message);
+    this.name = 'StripeSignatureVerificationError';
+  }
+}

--- a/src/lib/evershop/stripe/index.ts
+++ b/src/lib/evershop/stripe/index.ts
@@ -1,0 +1,6 @@
+export * from './errors';
+export * from './types';
+export * from './client';
+export * from './stripeGateway';
+export * from './webhook';
+export * from './config';

--- a/src/lib/evershop/stripe/stripeGateway.ts
+++ b/src/lib/evershop/stripe/stripeGateway.ts
@@ -1,0 +1,244 @@
+import { createStripeClient } from './client';
+import {
+  CaptureResult,
+  CreatePaymentIntentOptions,
+  PaymentIntentResult,
+  RefundResult,
+  StripeGatewayConfig,
+  StripeOrderSummary,
+} from './types';
+import { StripeConfigurationError, StripeGatewayError } from './errors';
+
+const STRIPE_PAYMENT_INTENT_PATH = '/payment_intents';
+const STRIPE_REFUND_PATH = '/refunds';
+
+function assertConfig(config: StripeGatewayConfig) {
+  if (!config.secretKey) {
+    throw new StripeConfigurationError('Stripe secret key is missing');
+  }
+
+  if (!config.publishableKey) {
+    throw new StripeConfigurationError('Stripe publishable key is missing');
+  }
+
+  if (!config.webhookSecret) {
+    throw new StripeConfigurationError('Stripe webhook secret is missing');
+  }
+
+  if (!config.currency) {
+    throw new StripeConfigurationError('Stripe currency is missing');
+  }
+}
+
+function toMinorUnits(amount: number) {
+  return Math.round(amount * 100);
+}
+
+function appendMetadata(
+  params: URLSearchParams,
+  metadata?: Record<string, string | number | null | undefined>,
+) {
+  if (!metadata) {
+    return;
+  }
+
+  Object.entries(metadata).forEach(([key, value]) => {
+    if (value === undefined || value === null) {
+      return;
+    }
+
+    params.append(`metadata[${key}]`, String(value));
+  });
+}
+
+function getPaymentIntentNextAction(intent: Record<string, unknown>) {
+  const nextAction = intent?.next_action as Record<string, unknown> | undefined;
+  if (!nextAction) {
+    return undefined;
+  }
+
+  return (nextAction.type as string | undefined) ?? undefined;
+}
+
+function normalisePaymentIntent(intent: Record<string, unknown>): PaymentIntentResult {
+  const amount = Number(intent.amount ?? 0);
+  const clientSecret = (intent.client_secret as string | undefined) ?? '';
+  const currency = (intent.currency as string | undefined) ?? '';
+  const status = (intent.status as string | undefined) ?? 'unknown';
+
+  return {
+    id: (intent.id as string | undefined) ?? '',
+    clientSecret,
+    status,
+    amount,
+    currency,
+    requiresAction: status === 'requires_action' || status === 'requires_source_action',
+    nextAction: getPaymentIntentNextAction(intent),
+    raw: intent,
+  };
+}
+
+function normaliseCaptureResult(intent: Record<string, unknown>): CaptureResult {
+  return {
+    id: (intent.id as string | undefined) ?? '',
+    status: (intent.status as string | undefined) ?? 'unknown',
+    amountCaptured: Number(intent.amount_received ?? intent.amount_capturable ?? 0),
+    raw: intent,
+  };
+}
+
+function normaliseRefund(refund: Record<string, unknown>): RefundResult {
+  return {
+    id: (refund.id as string | undefined) ?? '',
+    status: (refund.status as string | undefined) ?? 'unknown',
+    amountRefunded: Number(refund.amount ?? 0),
+    raw: refund,
+  };
+}
+
+export class StripePaymentGateway {
+  private readonly client = createStripeClient(this.config);
+
+  constructor(private readonly config: StripeGatewayConfig) {
+    assertConfig(config);
+  }
+
+  async createPaymentIntent(
+    order: StripeOrderSummary,
+    options: CreatePaymentIntentOptions = {},
+  ): Promise<PaymentIntentResult> {
+    const params = new URLSearchParams();
+    const currency = order.currency ?? this.config.currency;
+    const amountInMinorUnits = toMinorUnits(order.grandTotal);
+
+    if (amountInMinorUnits <= 0) {
+      throw new StripeGatewayError(
+        'Cannot create a payment intent for an order with a grand total lower or equal to zero.',
+      );
+    }
+
+    params.append('amount', String(amountInMinorUnits));
+    params.append('currency', currency.toLowerCase());
+
+    const captureMethod = options.captureMethod ?? this.config.captureMethod;
+    if (captureMethod) {
+      params.append('capture_method', captureMethod);
+    }
+
+    if (options.paymentMethodId) {
+      params.append('payment_method', options.paymentMethodId);
+    }
+
+    if (typeof options.confirm !== 'undefined') {
+      params.append('confirm', String(options.confirm));
+    }
+
+    if (order.returnUrl) {
+      params.append('return_url', order.returnUrl);
+    }
+
+    if (order.customerEmail) {
+      params.append('receipt_email', order.customerEmail);
+    }
+
+    if (order.description) {
+      params.append('description', order.description);
+    }
+
+    if (this.config.automaticPaymentMethods) {
+      params.append('automatic_payment_methods[enabled]', 'true');
+    } else if (this.config.paymentMethodTypes?.length) {
+      this.config.paymentMethodTypes.forEach((type, index) => {
+        params.append(`payment_method_types[${index}]`, type);
+      });
+    }
+
+    appendMetadata(params, {
+      ...this.config.metadata,
+      ...order.metadata,
+      orderId: order.id,
+      orderNumber: order.orderNumber,
+      customerName: order.customerName,
+    });
+
+    const rawIntent = await this.client.request<Record<string, unknown>>(
+      STRIPE_PAYMENT_INTENT_PATH,
+      {
+        body: params,
+        idempotencyKey: options.idempotencyKey,
+      },
+    );
+
+    return normalisePaymentIntent(rawIntent);
+  }
+
+  async confirmPaymentIntent(paymentIntentId: string, paymentMethodId?: string) {
+    const params = new URLSearchParams();
+
+    if (paymentMethodId) {
+      params.append('payment_method', paymentMethodId);
+    }
+
+    const rawIntent = await this.client.request<Record<string, unknown>>(
+      `${STRIPE_PAYMENT_INTENT_PATH}/${paymentIntentId}/confirm`,
+      {
+        body: params,
+      },
+    );
+
+    return normalisePaymentIntent(rawIntent);
+  }
+
+  async capturePaymentIntent(paymentIntentId: string, amount?: number): Promise<CaptureResult> {
+    const params = new URLSearchParams();
+
+    if (typeof amount === 'number') {
+      params.append('amount_to_capture', String(toMinorUnits(amount)));
+    }
+
+    const rawIntent = await this.client.request<Record<string, unknown>>(
+      `${STRIPE_PAYMENT_INTENT_PATH}/${paymentIntentId}/capture`,
+      {
+        body: params,
+      },
+    );
+
+    return normaliseCaptureResult(rawIntent);
+  }
+
+  async cancelPaymentIntent(paymentIntentId: string, reason?: string): Promise<PaymentIntentResult> {
+    const params = new URLSearchParams();
+
+    if (reason) {
+      params.append('cancellation_reason', reason);
+    }
+
+    const rawIntent = await this.client.request<Record<string, unknown>>(
+      `${STRIPE_PAYMENT_INTENT_PATH}/${paymentIntentId}/cancel`,
+      {
+        body: params,
+      },
+    );
+
+    return normalisePaymentIntent(rawIntent);
+  }
+
+  async refundPayment(paymentIntentId: string, amount?: number, reason?: string): Promise<RefundResult> {
+    const params = new URLSearchParams();
+    params.append('payment_intent', paymentIntentId);
+
+    if (typeof amount === 'number') {
+      params.append('amount', String(toMinorUnits(amount)));
+    }
+
+    if (reason) {
+      params.append('reason', reason);
+    }
+
+    const rawRefund = await this.client.request<Record<string, unknown>>(STRIPE_REFUND_PATH, {
+      body: params,
+    });
+
+    return normaliseRefund(rawRefund);
+  }
+}

--- a/src/lib/evershop/stripe/types.ts
+++ b/src/lib/evershop/stripe/types.ts
@@ -1,0 +1,119 @@
+export type StripeCaptureMethod = 'automatic' | 'manual';
+
+export interface StripeGatewayConfig {
+  /**
+   * Stripe secret key used to authenticate server side requests.
+   */
+  secretKey: string;
+  /**
+   * Stripe publishable key exposed to the client so that Stripe.js can be initialised.
+   */
+  publishableKey: string;
+  /**
+   * Webhook secret for validating the events coming from Stripe.
+   */
+  webhookSecret: string;
+  /**
+   * Default currency used when creating payment intents (e.g. `usd`).
+   */
+  currency: string;
+  /**
+   * Capture method controls if Stripe should capture the payment automatically
+   * or the capture will be executed manually after the order is processed.
+   */
+  captureMethod?: StripeCaptureMethod;
+  /**
+   * Optional metadata that is always sent alongside the payment intent.
+   */
+  metadata?: Record<string, string>;
+  /**
+   * Enable the automatic payment methods feature from Stripe.
+   */
+  automaticPaymentMethods?: boolean;
+  /**
+   * Define the list of payment method types that should be available when
+   * automatic payment methods are disabled.
+   */
+  paymentMethodTypes?: string[];
+}
+
+export interface StripeOrderSummary {
+  /** Internal identifier used by Evershop. */
+  id: string;
+  /** Human friendly order number displayed to the customer. */
+  orderNumber?: string;
+  /** Total amount of the order expressed in major units (e.g. dollars). */
+  grandTotal: number;
+  /** ISO-4217 currency code that should be used for the payment. */
+  currency?: string;
+  /** Email of the customer placing the order. */
+  customerEmail?: string;
+  /** Optional name of the customer. */
+  customerName?: string;
+  /**
+   * Return URL is used by Stripe to redirect the customer back to the storefront
+   * once the payment flow is completed.
+   */
+  returnUrl?: string;
+  /** Extra metadata you want to persist in Stripe dashboard. */
+  metadata?: Record<string, string | number | null | undefined>;
+  /** Description that should be visible on the bank statement. */
+  description?: string;
+}
+
+export interface CreatePaymentIntentOptions {
+  /** Payment method identifier collected on the client. */
+  paymentMethodId?: string;
+  /**
+   * When true the payment intent will not be confirmed right away. The caller
+   * can confirm it later by using {@link StripePaymentGateway.confirmPaymentIntent}.
+   */
+  confirm?: boolean;
+  /**
+   * Optional idempotency key. Reusing the same key allows us to safely retry a request.
+   */
+  idempotencyKey?: string;
+  /**
+   * Explicit capture method that overrides the default provided in the configuration.
+   */
+  captureMethod?: StripeCaptureMethod;
+}
+
+export interface PaymentIntentResult {
+  id: string;
+  clientSecret: string;
+  status: string;
+  amount: number;
+  currency: string;
+  requiresAction: boolean;
+  nextAction?: string;
+  raw: Record<string, unknown>;
+}
+
+export interface CaptureResult {
+  id: string;
+  status: string;
+  amountCaptured: number;
+  raw: Record<string, unknown>;
+}
+
+export interface RefundResult {
+  id: string;
+  status: string;
+  amountRefunded: number;
+  raw: Record<string, unknown>;
+}
+
+export interface StripeWebhookEvent<T = Record<string, unknown>> {
+  id: string;
+  type: string;
+  data: T;
+  apiVersion?: string;
+  created: number;
+}
+
+export interface StripeWebhookValidationResult<T = Record<string, unknown>> {
+  valid: boolean;
+  event?: StripeWebhookEvent<T>;
+  reason?: string;
+}

--- a/src/lib/evershop/stripe/webhook.ts
+++ b/src/lib/evershop/stripe/webhook.ts
@@ -1,0 +1,138 @@
+import {
+  StripeGatewayConfig,
+  StripeWebhookEvent,
+  StripeWebhookValidationResult,
+} from './types';
+import { StripeSignatureVerificationError } from './errors';
+
+interface StripeSignatureParts {
+  timestamp: number;
+  signatures: string[];
+}
+
+function parseSignatureHeader(header: string | null | undefined): StripeSignatureParts | null {
+  if (!header) {
+    return null;
+  }
+
+  const segments = header.split(',');
+  const timestampSegment = segments.find((segment) => segment.startsWith('t='));
+  const signatureSegments = segments
+    .filter((segment) => segment.startsWith('v1='))
+    .map((segment) => segment.replace('v1=', '').trim())
+    .filter(Boolean);
+
+  if (!timestampSegment || signatureSegments.length === 0) {
+    return null;
+  }
+
+  const timestamp = Number(timestampSegment.replace('t=', ''));
+  if (Number.isNaN(timestamp)) {
+    return null;
+  }
+
+  return {
+    timestamp,
+    signatures: signatureSegments,
+  };
+}
+
+function toHex(buffer: ArrayBuffer) {
+  const bytes = new Uint8Array(buffer);
+  const hex: string[] = [];
+  bytes.forEach((byte) => {
+    hex.push(byte.toString(16).padStart(2, '0'));
+  });
+  return hex.join('');
+}
+
+async function computeHmacSha256(secret: string, payload: string) {
+  const subtle = globalThis.crypto?.subtle;
+
+  if (!subtle) {
+    throw new StripeSignatureVerificationError(
+      'Web Crypto API is not available to compute the Stripe webhook signature',
+    );
+  }
+
+  const encoder = new TextEncoder();
+  const key = await subtle.importKey(
+    'raw',
+    encoder.encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+
+  const signature = await subtle.sign('HMAC', key, encoder.encode(payload));
+  return toHex(signature);
+}
+
+function safeCompare(expected: string, actual: string) {
+  if (expected.length !== actual.length) {
+    return false;
+  }
+
+  let mismatch = 0;
+  for (let index = 0; index < expected.length; index += 1) {
+    mismatch |= expected.charCodeAt(index) ^ actual.charCodeAt(index);
+  }
+
+  return mismatch === 0;
+}
+
+function parsePayload(payload: string): StripeWebhookEvent | undefined {
+  try {
+    return JSON.parse(payload) as StripeWebhookEvent;
+  } catch (error) {
+    console.warn('Unable to parse Stripe webhook payload', error);
+    return undefined;
+  }
+}
+
+function normalisePayload(payload: string | Uint8Array) {
+  if (typeof payload === 'string') {
+    return payload;
+  }
+
+  const decoder = new TextDecoder();
+  return decoder.decode(payload);
+}
+
+export async function validateStripeWebhookEvent(
+  payload: string | Uint8Array,
+  signatureHeader: string | null | undefined,
+  config: StripeGatewayConfig,
+  toleranceInSeconds = 300,
+): Promise<StripeWebhookValidationResult> {
+  const normalisedPayload = normalisePayload(payload);
+  const parsedSignature = parseSignatureHeader(signatureHeader);
+
+  if (!parsedSignature) {
+    return { valid: false, reason: 'invalid-signature-header' };
+  }
+
+  const { timestamp, signatures } = parsedSignature;
+  const currentTimestamp = Math.floor(Date.now() / 1000);
+
+  if (Math.abs(currentTimestamp - timestamp) > toleranceInSeconds) {
+    return { valid: false, reason: 'timestamp-out-of-range' };
+  }
+
+  const signedPayload = `${timestamp}.${normalisedPayload}`;
+  const expectedSignature = await computeHmacSha256(config.webhookSecret, signedPayload);
+
+  const valid = signatures.some((candidate) => safeCompare(candidate, expectedSignature));
+
+  if (!valid) {
+    return { valid: false, reason: 'signature-mismatch' };
+  }
+
+  const event = parsePayload(normalisedPayload);
+
+  if (!event) {
+    return { valid: false, reason: 'invalid-payload' };
+  }
+
+  return { valid: true, event };
+}


### PR DESCRIPTION
## Summary
- add a Stripe HTTP client and strongly typed gateway for the Evershop payment pipeline
- expose configuration helpers, error types, and webhook validation utilities for the Stripe integration

## Testing
- npm run build-no-errors *(fails: missing dependencies in the base project environment)*

------
https://chatgpt.com/codex/tasks/task_e_69035e6603e4832ba9d63aa45920ed07