### PR TITLE
Add shopping cart functionality and checkout flow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { Suspense } from "react";
 import { useRoutes, Routes, Route } from "react-router-dom";
 import Home from "./components/home";
+import CartPage from "./components/CartPage";
 import routes from "tempo-routes";
 
 function App() {
@@ -9,6 +10,7 @@ function App() {
       <>
         <Routes>
           <Route path="/" element={<Home />} />
+          <Route path="/cart" element={<CartPage />} />
         </Routes>
         {import.meta.env.VITE_TEMPO === "true" && useRoutes(routes)}
       </>

--- a/src/components/CartPage.tsx
+++ b/src/components/CartPage.tsx
@@ -1,0 +1,259 @@
+import { ChangeEvent, FormEvent, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import Header from "./Header";
+import { Button } from "./ui/button";
+import { Input } from "./ui/input";
+import { useCart } from "./cart/CartContext";
+
+const currencyFormatter = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+});
+
+function formatCurrency(value: number) {
+  return currencyFormatter.format(value);
+}
+
+const PAYMENT_DELAY_MS = 1200;
+
+const CartPage = () => {
+  const { items, subtotal, updateQuantity, removeItem, clearCart } = useCart();
+  const [isProcessing, setIsProcessing] = useState(false);
+  const [paymentComplete, setPaymentComplete] = useState(false);
+  const [formValues, setFormValues] = useState({
+    name: "",
+    email: "",
+    cardNumber: "",
+    expiration: "",
+    cvc: "",
+  });
+
+  const totals = useMemo(() => {
+    const shipping = items.length > 0 ? 25 : 0;
+    const tax = subtotal * 0.08;
+    const total = subtotal + shipping + tax;
+
+    return {
+      shipping,
+      tax,
+      total,
+    };
+  }, [items.length, subtotal]);
+
+  const handleQuantityChange = (id: string, value: string) => {
+    const parsedValue = Number.parseInt(value, 10);
+    if (Number.isNaN(parsedValue)) {
+      return;
+    }
+
+    updateQuantity(id, Math.max(1, parsedValue));
+  };
+
+  const handlePayment = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (!items.length || isProcessing) {
+      return;
+    }
+
+    setIsProcessing(true);
+
+    window.setTimeout(() => {
+      setIsProcessing(false);
+      setPaymentComplete(true);
+      clearCart();
+    }, PAYMENT_DELAY_MS);
+  };
+
+  const handleFieldChange = (field: keyof typeof formValues) =>
+    (event: ChangeEvent<HTMLInputElement>) => {
+      setFormValues((previous) => ({
+        ...previous,
+        [field]: event.target.value,
+      }));
+    };
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <Header />
+      <main className="pt-32 pb-16 px-4 md:px-8">
+        <div className="max-w-6xl mx-auto grid gap-10 lg:grid-cols-[2fr_1fr]">
+          <section className="bg-white rounded-xl shadow-sm border border-gray-100 p-6 md:p-10 space-y-8">
+            <div>
+              <h1 className="text-3xl font-light text-gray-900">Shopping Cart</h1>
+              <p className="mt-2 text-sm text-gray-500">
+                Review your selections, adjust quantities, and complete your purchase
+                when you&apos;re ready.
+              </p>
+            </div>
+
+            {paymentComplete ? (
+              <div className="bg-green-50 border border-green-200 rounded-lg p-6 space-y-3">
+                <h2 className="text-xl font-light text-green-900">Payment successful</h2>
+                <p className="text-sm text-green-800">
+                  Thank you for your order. A confirmation email has been sent to
+                  <span className="font-medium"> {formValues.email || "your inbox"}</span>.
+                </p>
+                <div>
+                  <Button asChild variant="outline" className="mt-2">
+                    <Link to="/">Continue exploring</Link>
+                  </Button>
+                </div>
+              </div>
+            ) : items.length === 0 ? (
+              <div className="border border-dashed border-gray-200 rounded-lg p-8 text-center space-y-4">
+                <p className="text-gray-600">Your cart is currently empty.</p>
+                <Button asChild>
+                  <Link to="/">Browse collections</Link>
+                </Button>
+              </div>
+            ) : (
+              <div className="space-y-6">
+                {items.map((item) => (
+                  <article
+                    key={item.id}
+                    className="flex flex-col md:flex-row gap-6 border-b border-gray-100 pb-6 last:border-none"
+                  >
+                    {item.image && (
+                      <img
+                        src={item.image}
+                        alt={item.name}
+                        className="w-full md:w-40 h-40 object-cover rounded-lg"
+                      />
+                    )}
+                    <div className="flex-1 space-y-4">
+                      <header className="flex flex-col md:flex-row md:items-start md:justify-between gap-4">
+                        <div>
+                          <h3 className="text-lg font-light text-gray-900">{item.name}</h3>
+                          {item.brand && (
+                            <p className="text-sm uppercase tracking-[0.2em] text-gray-400">
+                              {item.brand}
+                            </p>
+                          )}
+                          <p className="mt-2 text-sm text-gray-500">
+                            {formatCurrency(item.price)} each
+                          </p>
+                        </div>
+                        <Button
+                          variant="ghost"
+                          className="self-start text-sm text-gray-500 hover:text-gray-900"
+                          onClick={() => removeItem(item.id)}
+                        >
+                          Remove
+                        </Button>
+                      </header>
+
+                      <div className="flex flex-col sm:flex-row sm:items-center gap-4">
+                        <label className="text-sm text-gray-600" htmlFor={`qty-${item.id}`}>
+                          Quantity
+                        </label>
+                        <Input
+                          id={`qty-${item.id}`}
+                          type="number"
+                          min={1}
+                          value={item.quantity}
+                          onChange={(event) =>
+                            handleQuantityChange(item.id, event.target.value)
+                          }
+                          className="w-24"
+                        />
+                        <p className="sm:ml-auto text-base font-medium text-gray-900">
+                          {formatCurrency(item.price * item.quantity)}
+                        </p>
+                      </div>
+                    </div>
+                  </article>
+                ))}
+              </div>
+            )}
+          </section>
+
+          <aside className="space-y-6">
+            <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6 space-y-4">
+              <h2 className="text-xl font-light text-gray-900">Order summary</h2>
+              <div className="space-y-3 text-sm text-gray-600">
+                <div className="flex justify-between">
+                  <span>Subtotal</span>
+                  <span>{formatCurrency(subtotal)}</span>
+                </div>
+                <div className="flex justify-between">
+                  <span>Shipping</span>
+                  <span>{totals.shipping === 0 ? "Complimentary" : formatCurrency(totals.shipping)}</span>
+                </div>
+                <div className="flex justify-between">
+                  <span>Tax</span>
+                  <span>{formatCurrency(totals.tax)}</span>
+                </div>
+              </div>
+              <div className="flex justify-between border-t border-gray-100 pt-4 text-base font-medium text-gray-900">
+                <span>Total</span>
+                <span>{formatCurrency(totals.total)}</span>
+              </div>
+            </div>
+
+            {!paymentComplete && (
+              <form
+                onSubmit={handlePayment}
+                className="bg-white rounded-xl shadow-sm border border-gray-100 p-6 space-y-4"
+              >
+                <h2 className="text-xl font-light text-gray-900">Payment details</h2>
+                <p className="text-sm text-gray-500">
+                  Enter your billing information to complete the purchase.
+                </p>
+                <Input
+                  value={formValues.name}
+                  onChange={handleFieldChange("name")}
+                  placeholder="Full name"
+                  autoComplete="name"
+                  required
+                  disabled={!items.length || isProcessing}
+                />
+                <Input
+                  type="email"
+                  value={formValues.email}
+                  onChange={handleFieldChange("email")}
+                  placeholder="Email address"
+                  autoComplete="email"
+                  required
+                  disabled={!items.length || isProcessing}
+                />
+                <Input
+                  value={formValues.cardNumber}
+                  onChange={handleFieldChange("cardNumber")}
+                  placeholder="Card number"
+                  inputMode="numeric"
+                  autoComplete="cc-number"
+                  required
+                  disabled={!items.length || isProcessing}
+                />
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                  <Input
+                    value={formValues.expiration}
+                    onChange={handleFieldChange("expiration")}
+                    placeholder="MM/YY"
+                    autoComplete="cc-exp"
+                    required
+                    disabled={!items.length || isProcessing}
+                  />
+                  <Input
+                    value={formValues.cvc}
+                    onChange={handleFieldChange("cvc")}
+                    placeholder="CVC"
+                    autoComplete="cc-csc"
+                    required
+                    disabled={!items.length || isProcessing}
+                  />
+                </div>
+                <Button type="submit" disabled={!items.length || isProcessing} className="w-full">
+                  {isProcessing ? "Processing payment..." : `Pay ${formatCurrency(totals.total)}`}
+                </Button>
+              </form>
+            )}
+          </aside>
+        </div>
+      </main>
+    </div>
+  );
+};
+
+export default CartPage;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from "react";
 import { Link } from "react-router-dom";
 import { Search, ShoppingBag, Menu, X } from "lucide-react";
 import { motion, AnimatePresence } from "framer-motion";
+import { useCart } from "./cart/CartContext";
 
 interface HeaderProps {
   transparent?: boolean;
@@ -10,7 +11,7 @@ interface HeaderProps {
 const Header = ({ transparent = false }: HeaderProps) => {
   const [isScrolled, setIsScrolled] = useState(false);
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
-  const [cartCount, setCartCount] = useState(0);
+  const { totalItems } = useCart();
 
   useEffect(() => {
     const handleScroll = () => {
@@ -82,9 +83,9 @@ const Header = ({ transparent = false }: HeaderProps) => {
             className="relative hover:text-gray-500 transition-colors"
           >
             <ShoppingBag size={20} />
-            {cartCount > 0 && (
+            {totalItems > 0 && (
               <span className="absolute -top-1 -right-1 bg-black text-white text-xs w-4 h-4 flex items-center justify-center rounded-full">
-                {cartCount}
+                {totalItems}
               </span>
             )}
           </Link>

--- a/src/components/ProductCard.tsx
+++ b/src/components/ProductCard.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { motion } from "framer-motion";
 import { Button } from "./ui/button";
+import { useCart } from "./cart/CartContext";
 
 interface ProductCardProps {
   id?: string;
@@ -17,8 +18,29 @@ const ProductCard = ({
   brand = "Roots Studio",
   price = 299,
   image = "https://images.unsplash.com/photo-1513506003901-1e6a229e2d15?w=800&q=80",
-  onQuickAdd = () => console.log("Quick add clicked"),
+  onQuickAdd,
 }: ProductCardProps) => {
+  const { addItem } = useCart();
+
+  const handleQuickAdd = () => {
+    if (onQuickAdd) {
+      onQuickAdd();
+      return;
+    }
+
+    if (!id) {
+      return;
+    }
+
+    addItem({
+      id,
+      name,
+      brand,
+      price,
+      image,
+    });
+  };
+
   return (
     <motion.div
       className="group relative w-full h-full bg-white overflow-hidden"
@@ -39,7 +61,7 @@ const ProductCard = ({
         {/* Quick add button that appears on hover */}
         <div className="absolute bottom-0 left-0 right-0 p-4 translate-y-full group-hover:translate-y-0 transition-transform duration-300 ease-in-out">
           <Button
-            onClick={onQuickAdd}
+            onClick={handleQuickAdd}
             variant="outline"
             className="w-full bg-white hover:bg-gray-100 border-gray-200 text-gray-900 text-sm font-light"
           >

--- a/src/components/cart/CartContext.tsx
+++ b/src/components/cart/CartContext.tsx
@@ -1,0 +1,224 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useReducer,
+  type ReactNode,
+} from "react";
+
+export interface CartItem {
+  id: string;
+  name: string;
+  price: number;
+  image?: string;
+  brand?: string;
+  quantity: number;
+}
+
+type CartState = {
+  items: CartItem[];
+};
+
+type CartAction =
+  | { type: "ADD_ITEM"; payload: { item: Omit<CartItem, "quantity">; quantity: number } }
+  | { type: "REMOVE_ITEM"; payload: { id: string } }
+  | { type: "UPDATE_QUANTITY"; payload: { id: string; quantity: number } }
+  | { type: "SET_ITEMS"; payload: CartItem[] }
+  | { type: "CLEAR_CART" };
+
+export interface CartContextValue {
+  items: CartItem[];
+  totalItems: number;
+  subtotal: number;
+  addItem: (item: Omit<CartItem, "quantity">, quantity?: number) => void;
+  removeItem: (id: string) => void;
+  updateQuantity: (id: string, quantity: number) => void;
+  clearCart: () => void;
+}
+
+const initialState: CartState = {
+  items: [],
+};
+
+const CartContext = createContext<CartContextValue | undefined>(undefined);
+
+const STORAGE_KEY = "roots.design.cart";
+
+function cartReducer(state: CartState, action: CartAction): CartState {
+  switch (action.type) {
+    case "ADD_ITEM": {
+      const { item, quantity } = action.payload;
+      const existingItem = state.items.find((cartItem) => cartItem.id === item.id);
+
+      if (existingItem) {
+        return {
+          ...state,
+          items: state.items.map((cartItem) =>
+            cartItem.id === item.id
+              ? {
+                  ...cartItem,
+                  quantity: cartItem.quantity + quantity,
+                }
+              : cartItem,
+          ),
+        };
+      }
+
+      return {
+        ...state,
+        items: [...state.items, { ...item, quantity }],
+      };
+    }
+
+    case "REMOVE_ITEM": {
+      return {
+        ...state,
+        items: state.items.filter((item) => item.id !== action.payload.id),
+      };
+    }
+
+    case "UPDATE_QUANTITY": {
+      const { id, quantity } = action.payload;
+      if (quantity <= 0) {
+        return {
+          ...state,
+          items: state.items.filter((item) => item.id !== id),
+        };
+      }
+
+      return {
+        ...state,
+        items: state.items.map((item) =>
+          item.id === id
+            ? {
+                ...item,
+                quantity,
+              }
+            : item,
+        ),
+      };
+    }
+
+    case "SET_ITEMS": {
+      return {
+        ...state,
+        items: action.payload,
+      };
+    }
+
+    case "CLEAR_CART": {
+      return initialState;
+    }
+
+    default:
+      return state;
+  }
+}
+
+function deserializeCartItems(value: unknown): CartItem[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value
+    .filter((item) => typeof item === "object" && item !== null)
+    .map((item) => ({
+      id: String((item as CartItem).id),
+      name: String((item as CartItem).name),
+      price: Number((item as CartItem).price) || 0,
+      image: (item as CartItem).image ?? undefined,
+      brand: (item as CartItem).brand ?? undefined,
+      quantity: Math.max(1, Number((item as CartItem).quantity) || 1),
+    }));
+}
+
+export function CartProvider({ children }: { children: ReactNode }) {
+  const [state, dispatch] = useReducer(
+    cartReducer,
+    initialState,
+    (initial): CartState => {
+      if (typeof window === "undefined") {
+        return initial;
+      }
+
+      try {
+        const storedValue = window.localStorage.getItem(STORAGE_KEY);
+        if (!storedValue) {
+          return initial;
+        }
+
+        const parsed = JSON.parse(storedValue);
+        return {
+          items: deserializeCartItems(parsed),
+        };
+      } catch (error) {
+        console.error("Failed to read cart from storage", error);
+        return initial;
+      }
+    },
+  );
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    try {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(state.items));
+    } catch (error) {
+      console.error("Failed to persist cart", error);
+    }
+  }, [state.items]);
+
+  const addItem = useCallback(
+    (item: Omit<CartItem, "quantity">, quantity = 1) => {
+      if (!item?.id) {
+        return;
+      }
+
+      dispatch({ type: "ADD_ITEM", payload: { item, quantity: Math.max(1, quantity) } });
+    },
+    [],
+  );
+
+  const removeItem = useCallback((id: string) => {
+    dispatch({ type: "REMOVE_ITEM", payload: { id } });
+  }, []);
+
+  const updateQuantity = useCallback((id: string, quantity: number) => {
+    dispatch({ type: "UPDATE_QUANTITY", payload: { id, quantity } });
+  }, []);
+
+  const clearCart = useCallback(() => {
+    dispatch({ type: "CLEAR_CART" });
+  }, []);
+
+  const value = useMemo(() => {
+    const totalItems = state.items.reduce((total, item) => total + item.quantity, 0);
+    const subtotal = state.items.reduce((total, item) => total + item.price * item.quantity, 0);
+
+    return {
+      items: state.items,
+      totalItems,
+      subtotal,
+      addItem,
+      removeItem,
+      updateQuantity,
+      clearCart,
+    } satisfies CartContextValue;
+  }, [state.items, addItem, removeItem, updateQuantity, clearCart]);
+
+  return <CartContext.Provider value={value}>{children}</CartContext.Provider>;
+}
+
+export function useCart(): CartContextValue {
+  const context = useContext(CartContext);
+
+  if (!context) {
+    throw new Error("useCart must be used within a CartProvider");
+  }
+
+  return context;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from "react-dom/client";
 import App from "./App.tsx";
 import "./index.css";
 import { BrowserRouter } from "react-router-dom";
+import { CartProvider } from "./components/cart/CartContext";
 
 /* import { TempoDevtools } from 'tempo-devtools'; [deprecated] */
 /* TempoDevtools.init() [deprecated] */;
@@ -12,7 +13,9 @@ const basename = import.meta.env.BASE_URL;
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <BrowserRouter basename={basename}>
-      <App />
+      <CartProvider>
+        <App />
+      </CartProvider>
     </BrowserRouter>
   </React.StrictMode>,
 );


### PR DESCRIPTION
## Summary
- add a global cart context with localStorage persistence and helper actions
- wire quick-add buttons and the header badge into the cart state
- implement a dedicated cart page with an order summary and simulated payment form

## Testing
- npm install *(fails: 403 Forbidden - GET https://registry.npmjs.org/cypress)*

------
https://chatgpt.com/codex/tasks/task_e_6903760cc4cc832b918af40c39a27918